### PR TITLE
Upgrading javalin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 
 dependencies {
     //implementation name: 'jrpclightning-0.2.1-SNAPSHOT-with-dependencies'
-    implementation 'io.github.clightning4j:jrpclightning:0.2.1-SNAPSHOT'
+    implementation 'io.github.clightning4j:jrpclightning:0.2.1'
     implementation 'com.google.code.gson:gson:2.8.8'
 
     implementation 'io.javalin:javalin-bundle:4.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation 'io.github.clightning4j:jrpclightning:0.2.1-SNAPSHOT'
     implementation 'com.google.code.gson:gson:2.8.8'
 
-    implementation 'io.javalin:javalin-bundle:3.13.11'
+    implementation 'io.javalin:javalin-bundle:4.1.0'
 
     testImplementation 'com.squareup.okhttp3:okhttp:4.9.1'
     testImplementation 'org.mockito:mockito-core:3.12.1'

--- a/src/main/java/io/vincenzopalazzo/lightning/rest/CLightningRestPlugin.java
+++ b/src/main/java/io/vincenzopalazzo/lightning/rest/CLightningRestPlugin.java
@@ -114,7 +114,7 @@ public class CLightningRestPlugin extends CLightningPlugin {
         case "start":
           {
             plugin.log(PluginLog.INFO, "Server on port: " + port);
-            if (!Objects.requireNonNull(serverInstance.server()).getStarted()) {
+            if (!Objects.requireNonNull(serverInstance.jettyServer()).started) {
               serverInstance.start(port);
               response.add("status", "running");
               response.add("port", serverInstance.port());
@@ -125,7 +125,7 @@ public class CLightningRestPlugin extends CLightningPlugin {
           }
         case "stop":
           {
-            if (Objects.requireNonNull(serverInstance.server()).getStarted()) {
+            if (Objects.requireNonNull(serverInstance.jettyServer()).started) {
               serverInstance.stop();
               response.add("status", "shutdown");
               response.add("port", serverInstance.port());

--- a/src/main/java/io/vincenzopalazzo/lightning/rest/services/PaymentService.java
+++ b/src/main/java/io/vincenzopalazzo/lightning/rest/services/PaymentService.java
@@ -5,7 +5,6 @@ import io.javalin.http.InternalServerErrorResponse;
 import io.javalin.http.NotFoundResponse;
 import io.javalin.plugin.openapi.annotations.*;
 import io.vincenzopalazzo.lightning.rest.model.ErrorMessage;
-import java.util.Objects;
 import jrpc.clightning.CLightningRPC;
 import jrpc.clightning.exceptions.CLightningException;
 import jrpc.clightning.model.CLightningDecodePay;
@@ -165,13 +164,20 @@ public class PaymentService {
             content = {@OpenApiContent(from = CLightningInvoice.class)})
       }) // TODO complete the documentation
   public static void invoice(Context context) {
-    String milliSatoshi = context.formParam("msat", String.class).check(i -> !i.isEmpty()).get();
-    String label = context.formParam("label", String.class).check(i -> !i.isEmpty()).get();
+    String milliSatoshi =
+        context
+            .formParamAsClass("msat", String.class)
+            .check(i -> !i.isEmpty(), "msat value is not empty")
+            .get();
+    String label =
+        context
+            .formParamAsClass("label", String.class)
+            .check(i -> !i.isEmpty(), "label value is not empty")
+            .get();
     String description =
         context
-            .formParam("description", String.class)
-            .check(Objects::nonNull)
-            .check(i -> !i.isEmpty())
+            .formParamAsClass("description", String.class)
+            .check(i -> !i.isEmpty(), "description is not empty")
             .get();
     String expiry = context.formParam("expiry");
     if (expiry == null || expiry.isEmpty()) {

--- a/src/main/java/io/vincenzopalazzo/lightning/rest/services/PluginServices.java
+++ b/src/main/java/io/vincenzopalazzo/lightning/rest/services/PluginServices.java
@@ -35,8 +35,8 @@ public class PluginServices {
       })
   public static void diagnostic(Context context, ICLightningPlugin plugin) {
     try {
-      Integer metricId = context.queryParam("metric_id", Integer.class).getOrNull();
-      String metricsId = context.queryParam("metrics_id", String.class).getOrNull();
+      Integer metricId = context.queryParamAsClass("metric_id", Integer.class).getOrDefault(null);
+      String metricsId = context.queryParamAsClass("metrics_id", String.class).getOrDefault(null);
       HashMap<String, Object> payload = new HashMap<>();
       if ((metricsId != null && !metricsId.isEmpty()) && metricId != null)
         UtilsService.makeErrorResponse(context, "Specified metric_id or metrics_id not both");

--- a/src/main/java/io/vincenzopalazzo/lightning/rest/services/UtilityServices.java
+++ b/src/main/java/io/vincenzopalazzo/lightning/rest/services/UtilityServices.java
@@ -52,7 +52,7 @@ public class UtilityServices {
             content = {@OpenApiContent(from = CLightningListFunds.class)})
       })
   public static void listFunds(Context context) {
-    Boolean spent = context.formParam("spent", Boolean.class).getOrNull();
+    Boolean spent = context.formParamAsClass("spent", Boolean.class).getOrDefault(null);
     if (spent == null) spent = false;
     try {
       // TODO add method in the list funds

--- a/src/main/java/io/vincenzopalazzo/lightning/rest/utils/ServerUtils.java
+++ b/src/main/java/io/vincenzopalazzo/lightning/rest/utils/ServerUtils.java
@@ -66,7 +66,7 @@ public class ServerUtils {
     url = String.format("%s/%s", PAYMENT_SECTION, Command.DECODEPAY.getCommandKey());
     serverInstance.post(url, PaymentService::decodePay);
 
-    url = String.format("%s/%s/:label", PAYMENT_SECTION, Command.DELINVOICE.getCommandKey());
+    url = String.format("%s/%s/{label}", PAYMENT_SECTION, Command.DELINVOICE.getCommandKey());
     serverInstance.delete(url, PaymentService::delInvoice);
 
     url = String.format("%s/%s", PAYMENT_SECTION, Command.INVOICE.getCommandKey());
@@ -74,7 +74,7 @@ public class ServerUtils {
   }
 
   private static void setBitcoinServices(Javalin serverInstance) {
-    String url = String.format("%s/%s/:type", BITCOIN_SECTION, Command.NEWADDR.getCommandKey());
+    String url = String.format("%s/%s/{type}", BITCOIN_SECTION, Command.NEWADDR.getCommandKey());
     serverInstance.get(url, BitcoinServices::newAddr);
 
     url = String.format("%s/%s", BITCOIN_SECTION, Command.WITHDRAW.getCommandKey());
@@ -90,7 +90,7 @@ public class ServerUtils {
   }
 
   private static void setNetworkServices(Javalin servicesInstance) {
-    String url = String.format("%s/%s/:nodeId", NETWORK_SECTION, Command.PING.getCommandKey());
+    String url = String.format("%s/%s/{nodeId}", NETWORK_SECTION, Command.PING.getCommandKey());
     servicesInstance.get(url, NetworkServices::ping);
 
     url = String.format("%s/%s", NETWORK_SECTION, Command.LISTNODES.getCommandKey());

--- a/src/test/java/io/vincenzopalazzo/lightning/rest/BitcoinServiceTest.java
+++ b/src/test/java/io/vincenzopalazzo/lightning/rest/BitcoinServiceTest.java
@@ -21,7 +21,6 @@ public class BitcoinServiceTest extends AbstractServiceTest {
       var address = CLightningRPC.getInstance().newAddress(AddressType.P2SH_SEGWIT);
       HttpResponse response = Unirest.get("/bitcoin/newaddr/p2sh-segwit").asString();
       var toTest = response.getBody().toString();
-      toTest = toTest.substring(1, toTest.length() - 1);
       LOGGER.debug("POST_invoice response: " + toTest);
       LOGGER.debug("POST_invoice address expected length: " + address);
       assertThat(response.getStatus()).isEqualTo(200);
@@ -38,7 +37,6 @@ public class BitcoinServiceTest extends AbstractServiceTest {
       var address = CLightningRPC.getInstance().newAddress(AddressType.BECH32);
       HttpResponse response = Unirest.get("/bitcoin/newaddr/bech32").asString();
       var toTest = response.getBody().toString();
-      toTest = toTest.substring(1, toTest.length() - 1);
       LOGGER.debug("POST_invoice response: " + toTest);
       LOGGER.debug("POST_invoice address expected length: " + address);
       assertThat(response.getStatus()).isEqualTo(200);

--- a/src/test/java/io/vincenzopalazzo/lightning/rest/NetworkServiceTest.java
+++ b/src/test/java/io/vincenzopalazzo/lightning/rest/NetworkServiceTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assume.assumeThat;
 
-import io.javalin.plugin.json.JavalinJson;
+import io.javalin.plugin.json.JavalinJackson;
 import io.vincenzopalazzo.lightning.testutil.AbstractServiceTest;
 import jrpc.clightning.CLightningRPC;
 import junit.framework.TestCase;
@@ -33,7 +33,7 @@ public class NetworkServiceTest extends AbstractServiceTest {
     assumeThat(rpc.getInfo().getNetwork(), is("testnet"));
     try {
       var allNodes = CLightningRPC.getInstance().listNodes();
-      String asString = JavalinJson.toJson(allNodes);
+      String asString = new JavalinJackson().toJsonString(allNodes);
       HttpResponse response = Unirest.get("/network/listnodes").asString();
       LOGGER.debug("POST_invoice response: " + response.getBody().toString());
       assertThat(response.getStatus()).isEqualTo(200);

--- a/src/test/java/io/vincenzopalazzo/lightning/rest/PaymentServiceTest.java
+++ b/src/test/java/io/vincenzopalazzo/lightning/rest/PaymentServiceTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assume.assumeThat;
 
-import io.javalin.plugin.json.JavalinJson;
+import io.javalin.plugin.json.JavalinJackson;
 import io.vincenzopalazzo.lightning.testutil.AbstractServiceTest;
 import jrpc.clightning.exceptions.CLightningException;
 import junit.framework.TestCase;
@@ -19,7 +19,7 @@ public class PaymentServiceTest extends AbstractServiceTest {
     // payment/listinvoice
     try {
       var listInvoices = rpc.listInvoices();
-      String jsonResult = JavalinJson.toJson(listInvoices);
+      String jsonResult = new JavalinJackson().toJsonString(listInvoices);
       HttpResponse response = Unirest.get("/payment/listinvoice").asString();
       LOGGER.debug("GET_listInvoice response: " + response.getBody().toString());
       assertThat(response.getStatus()).isEqualTo(200);
@@ -38,7 +38,7 @@ public class PaymentServiceTest extends AbstractServiceTest {
       TestCase.assertFalse(listInvoice.isEmpty());
       invoice = listInvoice.get(0);
       TestCase.assertNotNull(invoice.getBolt11());
-      String jsonResult = JavalinJson.toJson(invoice);
+      String jsonResult = new JavalinJackson().toJsonString(invoice);
       HttpResponse response =
           Unirest.post("/payment/listinvoice").field("label", invoice.getLabel()).asString();
       LOGGER.debug("GET_listInvoice response: " + response.getBody().toString());
@@ -55,7 +55,7 @@ public class PaymentServiceTest extends AbstractServiceTest {
     try {
       var invoice = this.rpc.invoice("1000", "test", "test");
       var expected = rpc.decodePay(invoice.getBolt11());
-      String jsonResult = JavalinJson.toJson(expected);
+      String jsonResult = new JavalinJackson().toJsonString(expected);
 
       HttpResponse response =
           Unirest.post("/payment/decodepay").field("bolt11", invoice.getBolt11()).asString();
@@ -74,7 +74,7 @@ public class PaymentServiceTest extends AbstractServiceTest {
       var num = Math.random();
       var invoice = rpc.invoice("1000", "test-invoice-" + num, "test");
       invoice = rpc.listInvoices("test-invoice-" + num).getListInvoice().get(0);
-      String jsonResult = JavalinJson.toJson(invoice);
+      String jsonResult = new JavalinJackson().toJsonString(invoice);
       TestCase.assertNotNull(invoice.getStatus());
       TestCase.assertNotNull(invoice.getLabel());
 

--- a/src/test/java/io/vincenzopalazzo/lightning/rest/UtilsServiceTest.java
+++ b/src/test/java/io/vincenzopalazzo/lightning/rest/UtilsServiceTest.java
@@ -2,7 +2,7 @@ package io.vincenzopalazzo.lightning.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.javalin.plugin.json.JavalinJson;
+import io.javalin.plugin.json.JavalinJackson;
 import io.vincenzopalazzo.lightning.testutil.AbstractServiceTest;
 import jrpc.clightning.exceptions.CLightningException;
 import junit.framework.TestCase;
@@ -15,7 +15,7 @@ public class UtilsServiceTest extends AbstractServiceTest {
   public void GET_getInfoNode() {
     try {
       var getInfo = rpc.getInfo();
-      var jsonResult = JavalinJson.toJson(getInfo);
+      var jsonResult = new JavalinJackson().toJsonString(getInfo);
       var response = Unirest.get("/utility/getinfo").asString();
 
       LOGGER.debug("GET_getInfoNode response: " + response.getBody());
@@ -30,7 +30,7 @@ public class UtilsServiceTest extends AbstractServiceTest {
   public void GET_listFunds() {
     try {
       var getInfo = rpc.listFunds();
-      var jsonResult = JavalinJson.toJson(getInfo);
+      var jsonResult = new JavalinJackson().toJsonString(getInfo);
       var response = Unirest.get("/utility/listfounds").asString();
 
       LOGGER.debug("GET_listFunds response: " + response.getBody());


### PR DESCRIPTION
- [x] Addressing https://github.com/clightning4j/jrest/issues/17
- [x] Updating methods to match updates in `Javalin 4.x` - reviewed latest **[documentation](https://javalin.io/documentation)** and compared against version 3 [documentation](https://javalin.io/archive/docs/v3.13.X.html)
- [x] Reviewed both [this ](https://javalin.io/tutorials/testing) guide and [this ](https://github.com/tipsy/javalin-testing-example/blob/master/src/test/java/io/javalin/example/java/FunctionalTest.java) reference to update tests to use `JavalinJackson` since `JavalinJson` is no longer supported.

For `BitcoinServiceTest` - I tried debugging this but could not figure it why this was needed in the previous version. When I upgraded to `Javalin 4.1.0`, this line caused issues so I removed this line in 2 tests. A 200 is coming back, but with 2 extra characters for each test.
` toTest = toTest.substring(1, toTest.length() - 1);`

Fixes https://github.com/clightning4j/jrest/issues/17

Errors with that line, in the test:
![image](https://user-images.githubusercontent.com/10750101/135917203-30813997-cfef-46d1-aab9-3d182029f259.png)
![image](https://user-images.githubusercontent.com/10750101/135917269-f2d762cf-1ad0-43d2-a4f6-8cbf9e6b8c5c.png)
