### PR TITLE
fixed performance issue during the catch of the rpc_method hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
 # Ignore Gradle project-specific cache directory
 .gradle
+
+# Ignore Gradle build output directory
 build
 .idea/
+**/*.jar
+**/*.sh
+
+# .DS_Store for OSX
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# 
-
 <div align="center">
   <h1>:zap: JRest :zap:</h1>
 
@@ -34,11 +32,16 @@ A Java plugin for c-lightning to expose the API over rest!
 
 TODO: open a discussion to receive more feedback
 
+## Plugin parameter
+
+- jrest-port: the port where you want to run the plugin
+- jrest-on-startup: run the server at startup with core lightning
+
 ### Compile plugin
 
-TODO, for now open a discussion :)
+TODO, for now open it is a discussion :)
 
-### Link the plugin in c-lightning
+### Link the plugin in core lightning
 
 You can run the plugin in a different way
 
@@ -67,7 +70,7 @@ When you have installed the plugin, you can run it with the following command>
 ```
 
 You can visit the documentation of server rest at link
-[http://localhost:7000/jrest-ui#/](http://localhost:7000/jrest-ui#/) on your
+[http://localhost:7000/ui](http://localhost:7000/ui) on your
 browser
 
 - `lightning-cli restserver stop`: This command stop the server and the caller

--- a/build.gradle
+++ b/build.gradle
@@ -18,25 +18,25 @@ repositories {
 dependencies {
     //implementation name: 'jrpclightning-0.2.1-SNAPSHOT-with-dependencies'
     implementation 'io.github.clightning4j:jrpclightning:0.2.2'
-    implementation 'com.google.code.gson:gson:2.8.8'
+    implementation 'com.google.code.gson:gson:2.9.0'
 
-    implementation 'io.javalin:javalin-bundle:4.1.0'
+    implementation 'io.javalin:javalin-bundle:4.6.0'
 
-    testImplementation 'com.squareup.okhttp3:okhttp:4.9.1'
-    testImplementation 'org.mockito:mockito-core:3.12.4'
+    testImplementation 'com.squareup.okhttp3:okhttp:4.9.3'
+    testImplementation 'org.mockito:mockito-core:4.5.1'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'com.konghq:unirest-java:3.13.0'
-    testImplementation 'org.assertj:assertj-core:3.21.0'
-    testImplementation 'ch.qos.logback:logback-classic:1.2.6'
-    testImplementation 'ch.qos.logback:logback-core:1.2.6'
-    testImplementation 'org.slf4j:slf4j-api:1.7.32'
+    testImplementation 'com.konghq:unirest-java:3.13.8'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'ch.qos.logback:logback-classic:1.2.11'
+    testImplementation 'ch.qos.logback:logback-core:1.2.11'
+    testImplementation 'org.slf4j:slf4j-api:1.7.36'
 }
 
 jar {
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     manifest {
         attributes(
-                'Class-Path': configurations.runtimeClasspath.collect { it.getName() }.join(' '),
+                'Class-Path': configurations.compileClasspath.collect { it.getName() }.join(' '),
                 'Main-Class': 'io.vincenzopalazzo.lightning.App'
         )
     }
@@ -50,8 +50,8 @@ task createRunnableScript {
     dependsOn("jar")
     file("${projectDir}/${project.name}-gen.sh").createNewFile()
     file("${projectDir}/${project.name}-gen.sh").write(
-            """# Script generated from gradle! By clightning4j
-#!/bin/bash
+            """#!/bin/bash
+# Script generated from gradle! By clightning4j
 ${System.getProperties().getProperty("java.home")}/bin/java -jar ${project.buildDir.absolutePath}/libs/${project.name}.jar
 """)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -33,9 +33,10 @@ dependencies {
 }
 
 jar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     manifest {
         attributes(
-                'Class-Path': configurations.compile.collect { it.getName() }.join(' '),
+                'Class-Path': configurations.runtimeClasspath.collect { it.getName() }.join(' '),
                 'Main-Class': 'io.vincenzopalazzo.lightning.App'
         )
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Fri Jul 03 21:46:25 MST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/lightning-rest-gen.sh
+++ b/lightning-rest-gen.sh
@@ -1,3 +1,0 @@
-# Script generated from gradle! By clightning4j
-#!/bin/bash
-/usr/lib/jvm/jdk-11.0.10/bin/java -jar /home/vincent/Github/clightning4j/lightning-rest/build/libs/lightning-rest.jar

--- a/src/main/java/io/vincenzopalazzo/lightning/rest/CLightningRestPlugin.java
+++ b/src/main/java/io/vincenzopalazzo/lightning/rest/CLightningRestPlugin.java
@@ -100,8 +100,7 @@ public class CLightningRestPlugin extends CLightningPlugin {
     if (onStartupCalled != null && !onStartupCalled) {
       response.add("message", "Waiting first initialization by c-lightning");
     } else {
-      if (serverInstance == null)
-        serverInstance = ServerUtils.buildServerInstance(plugin);
+      if (serverInstance == null) serverInstance = ServerUtils.buildServerInstance(plugin);
       JsonArray params = request.get("params").getAsJsonArray();
       if (params.isEmpty()) {
         response.add("error", "JSON array is empty we need to know the operation, start or stop");


### PR DESCRIPTION
included https://github.com/clightning4j/jrest/pull/29

This PR fixed the performance issue during the catch of the `rpc_method` hook.

The issue reported by @gautamjajoo was not a real bug looks like the Java API is a little bit slow to handle a lot of rpc_hook calls so maybe it needs more investigation in the near future.

But for now, using a new feature of core lightning we are able to run again the plugin.

Thanks for all the hard work @gautamjajoo and @swaptr

